### PR TITLE
Added support to ruby 2.5.0 and 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ env:
     - CC_TEST_REPORTER_ID=64987eb47d7d4674b92284c32a53996b153d911e7957f2e7b66eeb4500a2a79e
 language: ruby
 rvm:
-  - 2.2.8
   - 2.3.5
   - 2.4.2
+  - 2.5.0
+  - 2.5.1
 before_install: gem install bundler -v 1.15.4
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We all love emojis, but sometimes unfortunately we can't handle them. Use these 
 
 Supports ActiveModel > 4
 
-Tested against Ruby 2.3 and 2.4
+Tested against Ruby 2.3, 2.4, 2.5 and 2.5.1
 
 Depends on the [unicode-emoji](https://rubygems.org/gems/unicode-emoji) gem.
 

--- a/emoji-validator.gemspec
+++ b/emoji-validator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
   spec.bindir                = 'exe'
   spec.executables           = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.required_ruby_version = ['>= 2.2.8', '< 2.5.0']
+  spec.required_ruby_version = ['>= 2.2.8', '< 2.6.0']
   spec.require_paths         = ['lib']
 
   spec.add_dependency 'activemodel', '>= 4'

--- a/emoji-validator.gemspec
+++ b/emoji-validator.gemspec
@@ -1,7 +1,6 @@
-
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'emoji/validator/version'
 

--- a/lib/emoji/validator/no_emoji_anywhere_validator.rb
+++ b/lib/emoji/validator/no_emoji_anywhere_validator.rb
@@ -20,6 +20,7 @@ module Emoji
         base.class_eval do
           columns_hash.each do |k, v|
             next unless %i[string text].include?(v.type)
+
             validates k, no_emoji: true
           end
         end

--- a/lib/emoji/validator/no_emoji_validator.rb
+++ b/lib/emoji/validator/no_emoji_validator.rb
@@ -18,6 +18,7 @@ module Emoji
       def validate_each(record, attribute, value)
         return if value.nil?
         return if value.match(Unicode::Emoji::REGEX_VALID).nil?
+
         record.errors.add(attribute, :has_emojis)
       end
     end


### PR DESCRIPTION
Add support to ruby 2.5.0 and 2.5.1.

Fixes rubocop issues:

```
Offenses:
emoji-validator.gemspec:2:1: C: Layout/LeadingBlankLines: Unnecessary blank line at the beginning of the source.
# frozen_string_literal: true
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
emoji-validator.gemspec:4:12: C: Style/ExpandPathArguments: Use expand_path('lib', __dir__) instead of expand_path('../lib', __FILE__).
lib = File.expand_path('../lib', __FILE__)
           ^^^^^^^^^^^
lib/emoji/validator/no_emoji_anywhere_validator.rb:22:13: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
            next unless %i[string text].include?(v.type)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/emoji/validator/no_emoji_validator.rb:20:9: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
        return if value.match(Unicode::Emoji::REGEX_VALID).nil?
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
12 files inspected, 4 offenses detected
The command "bundle exec rubocop" exited with 1.
```